### PR TITLE
delete async inside forEach of filterFunction

### DIFF
--- a/packages/vulcan-lib/lib/modules/mongoParams.js
+++ b/packages/vulcan-lib/lib/modules/mongoParams.js
@@ -107,7 +107,7 @@ export const filterFunction = async (collection, input = {}, context) => {
 
   // filter
   if (!isEmpty(filter)) {
-    Object.keys(filter).forEach(async fieldName => {
+    Object.keys(filter).forEach(fieldName => {
       switch (fieldName) {
         case '_and':
           filteredFields = filteredFields.concat(getFieldNames(filter._and));


### PR DESCRIPTION
Deletes the `async` on the `forEach` callback as we're not `await`ing anything in there.

It looks like it was accidentally left-over from a previous commit.