### PR TITLE
create2 delete2 multiQueryUpdater minor changes

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/create2.js
+++ b/packages/vulcan-core/lib/modules/containers/create2.js
@@ -50,8 +50,8 @@ export const multiQueryUpdater = ({
   fragment,
   fragmentName,
   collection,
-  resolverName,
 }) => async (cache, { data }) => {
+  const resolverName = `create${typeName}`;
   const multiResolverName = collection.options.multiResolverName;
   // update multi queries
   const multiQuery = buildMultiQuery({ typeName, fragmentName, fragment });
@@ -102,10 +102,8 @@ export const useCreate2 = (options) => {
 
   const query = buildCreateQuery({ typeName, fragmentName, fragment });
 
-  const resolverName = `create${typeName}`;
-
   const [createFunc, ...rest] = useMutation(query, {
-    update: multiQueryUpdater({ typeName, fragment, fragmentName, collection, resolverName }),
+    update: multiQueryUpdater({ typeName, fragment, fragmentName, collection }),
     ...mutationOptions
   });
 
@@ -114,6 +112,7 @@ export const useCreate2 = (options) => {
     const executionResult = await createFunc({
       variables: { data: args.data },
     });
+    const resolverName = `create${typeName}`;
     return buildResult(options, resolverName, executionResult);
   };
   return [extendedCreateFunc, ...rest];

--- a/packages/vulcan-core/lib/modules/containers/delete2.js
+++ b/packages/vulcan-core/lib/modules/containers/delete2.js
@@ -43,7 +43,7 @@ export const buildDeleteQuery = ({ typeName, fragmentName, fragment }) => (
 );
 
 // remove value from the cached lists
-const multiQueryUpdater = ({ collection, typeName, fragmentName, fragment }) => {
+export const multiQueryUpdater = ({ collection, typeName, fragmentName, fragment }) => {
   const multiResolverName = collection.options.multiResolverName;
   const deleteResolverName = `delete${typeName}`;
   return (cache, { data }) => {


### PR DESCRIPTION
1. export the `multiQueryUpdater` from delete2.js so we can use it with our own args from our app
2. remove the `resolverName` argument to the create2.js `multiQueryUpdater` because it can be created inside the function (we shouldn't have to pass the string from our app)